### PR TITLE
Openapi support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.6
 
 ADD requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/id_mapper/app.py
+++ b/id_mapper/app.py
@@ -28,7 +28,11 @@ from id_mapper.graph import find_match, NoSuchNode
 
 
 class IDMapping(Service):
-    @http.GET('./query')
+    @http.GET(
+        './query',
+        description='Query entity by id and database name to get '
+                    'all the matching IDs from another database'
+    )
     def query(self, request: QueryRequest) -> QueryResponse:
         graph = Graph(
             host=os.environ['DB_PORT_7687_TCP_ADDR'],

--- a/id_mapper/app.py
+++ b/id_mapper/app.py
@@ -20,6 +20,7 @@ from aiohttp import web
 from venom.rpc import Service, Venom
 from venom.rpc.comms.aiohttp import create_app
 from venom.rpc.method import http
+from venom.rpc.reflect.service import ReflectService
 from venom.exceptions import NotFound
 
 from id_mapper.stubs import QueryRequest, QueryResponse
@@ -29,7 +30,10 @@ from id_mapper.graph import find_match, NoSuchNode
 class IDMapping(Service):
     @http.GET('./query')
     def query(self, request: QueryRequest) -> QueryResponse:
-        graph = Graph(host=os.environ['DB_PORT_7687_TCP_ADDR'], password=os.environ['NEO4J_PASSWORD'])
+        graph = Graph(
+            host=os.environ['DB_PORT_7687_TCP_ADDR'],
+            password=os.environ['NEO4J_PASSWORD']
+        )
         try:
             return QueryResponse(ids=find_match(
                 graph, request.id, request.db_from, request.db_to
@@ -39,6 +43,8 @@ class IDMapping(Service):
 
 venom = Venom()
 venom.add(IDMapping)
+venom.add(ReflectService)
+
 
 app = create_app(venom)
 

--- a/id_mapper/stubs.py
+++ b/id_mapper/stubs.py
@@ -19,13 +19,13 @@ from venom.rpc import Stub, http
 
 
 class QueryRequest(Message):
-    id = String()
-    db_from = String()
-    db_to = String()
+    id = String(description='Entity ID')
+    db_from = String(description='Database name for the entity ID')
+    db_to = String(description='Database name to map against')
 
 
 class QueryResponse(Message):
-    ids = Repeat(String())
+    ids = Repeat(String(), description='List of matching IDs')
 
 
 class IDMappingStub(Stub):

--- a/id_mapper/stubs.py
+++ b/id_mapper/stubs.py
@@ -15,8 +15,7 @@
 
 from venom.fields import String, Repeat
 from venom.message import Message
-from venom.rpc import Stub
-from venom.rpc.stub import RPC
+from venom.rpc import Stub, http
 
 
 class QueryRequest(Message):
@@ -30,4 +29,6 @@ class QueryResponse(Message):
 
 
 class IDMappingStub(Stub):
-    query = RPC.http.GET('./query', QueryRequest, QueryResponse)
+    @http.GET('./query')
+    def query(self, request: QueryRequest) -> QueryResponse:
+        raise NotImplementedError

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-venom==1.0.0a4
+git+https://github.com/biosustain/venom.git@feat/openapi#egg=venom
 requests
 codecov
 aiohttp


### PR DESCRIPTION
While waiting for the new version of `venom` to be released https://github.com/biosustain/venom/pull/7 we could still proceed with upgrading ID mapper interface to support batch processing, so `model` service can be moved forward as well.
Setting fields and methods description attribute is not required by the library, but highly encouraged, because the information goes straight to Swagger docs
