### PR TITLE
Add Sentry integration

### DIFF
--- a/id_mapper/__init__.py
+++ b/id_mapper/__init__.py
@@ -1,6 +1,19 @@
 import logging
 import sys
 
+from raven import Client
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
+
 logger = logging.getLogger('service-id-mapper')
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))
 logger.setLevel(logging.DEBUG)
+
+# Configure Raven to capture warning logs
+raven_client = Client(settings.SENTRY_DSN)
+handler = SentryHandler(raven_client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)

--- a/id_mapper/app.py
+++ b/id_mapper/app.py
@@ -27,6 +27,8 @@ from id_mapper.stubs import IdMapperQueryRequest, IdMapperQueryResponse
 from id_mapper.graph import query_identifiers
 from id_mapper import logger
 
+from .middleware import raven_middleware
+
 
 class IdMapping(Service):
     logger.info('connect to graph-db at {}'.format(os.environ['ID_MAPPER_API']))
@@ -51,7 +53,7 @@ venom = Venom()
 venom.add(IdMapping)
 venom.add(ReflectService)
 
-app = create_app(venom)
+app = create_app(venom, web.Application(middlewares=[raven_middleware]))
 
 if __name__ == '__main__':
     web.run_app(app)

--- a/id_mapper/middleware.py
+++ b/id_mapper/middleware.py
@@ -1,0 +1,12 @@
+from . import raven_client
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware which captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            raven_client.captureException()
+            raise
+    return middleware_handler

--- a/id_mapper/settings.py
+++ b/id_mapper/settings.py
@@ -12,5 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 
 METANETX_URL = 'http://www.metanetx.org/cgi-bin/mnxget/mnxref'
+SENTRY_DSN = os.environ.get('SENTRY_DSN', '')

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ gunicorn
 six
 py2neo
 pytest-cov==2.4.0
+raven==6.4.0


### PR DESCRIPTION
Adds Raven to capture error events to Sentry

- aiohttp middleware logs uncaught exceptions, and re-raises
- log events of `warning` or higher level